### PR TITLE
fix: k-means article link wrong

### DIFF
--- a/index.html
+++ b/index.html
@@ -126,7 +126,7 @@
             (a) <a href="https://distill.pub/2019/visual-exploration-gaussian-processes/" target="_blank">A Visual Exploration of Gaussian Processes</a> by Görtler, Kehlbeck, and Deussen (<a href="https://visxai.io/2018">VISxAI 2018</a>);
             (b) <a href="https://pair.withgoogle.com/explorables/fill-in-the-blank/" target="_blank">What Have Language Models Learned?</a> by Adam Pearce (<a href="https://visxai.io/2021">VISxAI 2021</a>);
             (c) <a href="https://theo-jaunet.github.io/MemoryReduction/" target="_blank">What if we Reduce the Memory of an Artificial Doom Player?</a> by Jaunet, Vuillemot, and Wolf (<a href="https://visxai.io/2019">VISxAI 2019</a>);
-            (d) <a href="https://tiga1231.github.io/umap-tour/" target="_blank">K-Means Clustering: An Explorable Explainer</a> by Yi Zhe Ang (<a href="https://visxai.io/2022">VISxAI 2022</a>);
+            (d) <a href="https://k-means-explorable.vercel.app/" target="_blank">K-Means Clustering: An Explorable Explainer</a> by Yi Zhe Ang (<a href="https://visxai.io/2022">VISxAI 2022</a>);
             (e) <a href="https://tiga1231.github.io/umap-tour/" target="_blank">Comparing DNNs with UMAP Tour</a> by Li and Scheidegger (<a href="https://visxai.io/2020">VISxAI 2020</a>);
             (f) <a href="https://parametric.press/issue-01/the-myth-of-the-impartial-machine/" target="_blank">The Myth of the Impartial Machine</a> by Feng and Wu (<a href="https://parametric.press/">Parametric Press</a>);
             (g) <a href="http://formafluens.io/client/mix10.html">FormaFluens Data Experiment</a> by Strobelt, Phibbs, and Martino.


### PR DESCRIPTION
redirects to umap tour incorrectly